### PR TITLE
No more ambassador/links. Add dockerfile args.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN git clone https://github.com/openstack/designate.git code
 
 # Select version of the code
 WORKDIR /code
-RUN git reset --hard 6aa43088033393878be0533ab246e86c45e17915
+RUN git reset --hard ${DESIGNATE_VERSION:-6aa43088033393878be0533ab246e86c45e17915}
 RUN pip install -r requirements.txt
 RUN pip install -e .
 
@@ -56,6 +56,10 @@ COPY mysql/setup_databases.sql setup_databases.sql
 
 # Copy over our designate config
 COPY etc/designate /etc/designate
+
+# Allow us to specify a custom designate.conf at container build time
+ARG DESIGNATE_CONF
+COPY ${DESIGNATE_CONF:-etc/designate/designate.conf} /etc/designate/designate.conf
 
 # add a separate designate.conf with localhost for the db connection so we can
 # use designate-manage to sync the db even if `mysql` is not in /etc/hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN git clone https://github.com/openstack/designate.git code
 
 # Select version of the code
 WORKDIR /code
+ARG DESIGNATE_VERSION
 RUN git reset --hard ${DESIGNATE_VERSION:-6aa43088033393878be0533ab246e86c45e17915}
 RUN pip install -r requirements.txt
 RUN pip install -e .

--- a/README.rst
+++ b/README.rst
@@ -9,28 +9,28 @@ on Carina!
 Getting Started
 ===============
 
-If you don't have carina installed, you can run `make bootstrap` and
+If you don't have carina installed, you can run ``make bootstrap`` and
 it will try to install the carina client via brew. This is still a
 work in progress, so if you run into problems take a look at the
 bootstrap target and follow the steps!
 
-Next up you want to `make cluster-create`. Again see the Makefile for
-info. To verify it is up and ready, you can run `make cluster-info`.
+Next up you want to ``make cluster-create``. Again see the Makefile for
+info. To verify it is up and ready, you can run ``make cluster-info``.
 
-Finally, you can run `make all`! That will:
+Finally, you can run ``make all``! That will:
 
-- run `make cluster-creds` to setup the cluster credentials
-- run `make build-containers` to build the image(s)
-- run `make start` to start designate
+- run ``make cluster-creds`` to setup the cluster credentials
+- run ``make build-containers`` to build the image(s)
+- run ``make start`` to start designate
 
 Hopefully the targets are reasonably self explanatory. The high level
 process is to use docker-compose to build the containers based on the
-Dockerfile in this repo. `docker-compose` will be used to build and
-start the services. The `migrate-db` task simply sets up the database
+Dockerfile in this repo. ``docker-compose`` will be used to build and
+start the services. The ``migrate-db`` task simply sets up the database
 schema.
 
-Once things are up, you can run `make ps` to see what is running.
-To see real-time logs from all services, you can run `make logs`.
+Once things are up, you can run ``make ps`` to see what is running.
+To see real-time logs from all services, you can run ``make logs``.
 
 
 Use the Makefile!

--- a/README.rst
+++ b/README.rst
@@ -14,16 +14,14 @@ it will try to install the carina client via brew. This is still a
 work in progress, so if you run into problems take a look at the
 bootstrap target and follow the steps!
 
-Next up you want to `make create-cluster`. Again see the Makefile for
+Next up you want to `make cluster-create`. Again see the Makefile for
 info. To verify it is up and ready, you can run `make cluster-info`.
 
 Finally, you can run `make all`! That will:
 
- - make build-containers
- - make start-backend
- - make migrate-db (get the database up and sync'd up before starting
-   services)
- - make start-designate
+- run `make cluster-creds` to setup the cluster credentials
+- run `make build-containers` to build the image(s)
+- run `make start` to start designate
 
 Hopefully the targets are reasonably self explanatory. The high level
 process is to use docker-compose to build the containers based on the
@@ -32,6 +30,7 @@ start the services. The `migrate-db` task simply sets up the database
 schema.
 
 Once things are up, you can run `make ps` to see what is running.
+To see real-time logs from all services, you can run `make logs`.
 
 
 Use the Makefile!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,108 +1,80 @@
-amba:
-  image: cpuguy83/docker-grand-ambassador
-  volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock"
-  command: "-name designatecarina_mdns_1"
+version: '2'
 
-bind-1:
-  build: .
-  ports:
-    - "53"
-    - "953"
-    - "53/udp"
-    - "953/udp"
-    - "5358/tcp"
-    - "5358/udp"
-  links:
-    - "amba:mdns"
+services:
+  base:
+    build:
+      context: .
+      args:
+        DESIGNATE_CONF: etc/designate/designate.conf
 
-  command: run-bind-with-agent.sh
+  bind-1:
+    image: designatecarina_base
+    ports:
+      - "53"
+      - "953"
+      - "53/udp"
+      - "953/udp"
+      - "5358/tcp"
+      - "5358/udp"
 
-bind-2:
-  build: .
-  ports:
-    - "53"
-    - "953"
-    - "53/udp"
-    - "953/udp"
-    - "5358/tcp"
-    - "5358/udp"
-  links:
-    - "amba:mdns"
+    command: run-bind-with-agent.sh
 
-  command: run-bind-with-agent.sh
+  bind-2:
+    image: designatecarina_base
+    ports:
+      - "53"
+      - "953"
+      - "53/udp"
+      - "953/udp"
+      - "5358/tcp"
+      - "5358/udp"
 
-mysql:
-  build: .
+    command: run-bind-with-agent.sh
 
-  ports:
-    - "3306"
+  mysql:
+    image: designatecarina_base
 
-  command: /usr/bin/mysqld_safe
+    ports:
+      - "3306"
 
-rabbit:
-  image: rabbitmq
+    command: /usr/bin/mysqld_safe
 
-  environment:
-    RABBITMQ_DEFAULT_USER: designate
-    RABBITMQ_DEFAULT_PASS: designate
+  rabbit:
+    image: rabbitmq
 
-  ports:
-    - "5672"
+    environment:
+      RABBITMQ_DEFAULT_USER: designate
+      RABBITMQ_DEFAULT_PASS: designate
 
-memcached:
-  image: memcached
-  ports:
-    - "11211:11211"
+    ports:
+      - "5672"
 
-api:
-  build: .
-  links:
-    - rabbit
+  memcached:
+    image: memcached
+    ports:
+      - "11211:11211"
 
-  ports:
-    - "9001"
+  api:
+    image: designatecarina_base
+    ports:
+      - "9001"
+    command: designate-api
 
-  command: designate-api
+  central:
+    image: designatecarina_base
+    command: designate-central
 
-central:
-  build: .
-  links:
-    - rabbit
-    - mysql
-
-  command: designate-central
-
-mdns:
-  build: .
-  links:
-    - rabbit
-    - mysql
-    - bind-1
-    - bind-2
-  ports:
-    - "5354"
-
-  command: designate-mdns
+  mdns:
+    image: designatecarina_base
+    ports:
+      - "5354"
+    command: designate-mdns
 
 
-poolmanager:
-  build: .
-  links:
-    - mdns
-    - bind-1
-    - bind-2
-    - rabbit
-    - memcached
-    - mysql
+  poolmanager:
+    image: designatecarina_base
+    command: designate-pool-manager
 
-  command: designate-pool-manager
-
-zonemanager:
-  build: .
-  links:
-    - rabbit
-    - memcached
-    - mysql
-
-  command: designate-zone-manager
+  zonemanager:
+    image: designatecarina_base
+    command: designate-zone-manager


### PR DESCRIPTION
- Switch docker-compose.yml to version 2. This gets docker-compose to
  create a bridge network by default. All your containers on this
  network are reachable by their name, so everything just works.
- Remove the ambassador container and all hardcoded links as a result
- Add a Dockerfile build arg for the designate.conf file
- Add a Dockerfile build arg for the designate version to checkout
- Refactor docker-compose.yml to build a base image that is reused by
  all other containers. This allows us to specify build args in one
  place in docker-compose.yml