### PR TITLE
Use rackspace's apt mirror to speed up docker builds

### DIFF
--- a/Dockerfile.bind
+++ b/Dockerfile.bind
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-COPY etc/apt/* /etc/apt/sources.list
+COPY etc/apt/* /etc/apt/
 RUN apt-get update && apt-get install -y bind9
 
 # Get our bind sorted

--- a/Dockerfile.bind
+++ b/Dockerfile.bind
@@ -1,5 +1,6 @@
 FROM ubuntu:14.04
 
+COPY etc/apt/* /etc/apt/sources.list
 RUN apt-get update && apt-get install -y bind9
 
 # Get our bind sorted

--- a/Dockerfile.designate
+++ b/Dockerfile.designate
@@ -1,5 +1,6 @@
 FROM ubuntu:14.04
 
+COPY etc/apt/* /etc/apt/sources.list
 COPY mysql/debconf_selections debconf_selections
 
 RUN debconf-set-selections -v debconf_selections

--- a/Dockerfile.designate
+++ b/Dockerfile.designate
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-COPY etc/apt/* /etc/apt/sources.list
+COPY etc/apt/* /etc/apt/
 COPY mysql/debconf_selections debconf_selections
 
 RUN debconf-set-selections -v debconf_selections

--- a/etc/apt/sources.list
+++ b/etc/apt/sources.list
@@ -1,0 +1,61 @@
+# deb http://mirror.rackspace.com/ubuntu trusty main restricted
+
+# deb http://mirror.rackspace.com/ubuntu trusty-updates main restricted
+# deb http://mirror.rackspace.com/ubuntu trusty-security main restricted
+
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://mirror.rackspace.com/ubuntu trusty main restricted
+deb-src http://mirror.rackspace.com/ubuntu trusty main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://mirror.rackspace.com/ubuntu trusty-updates main restricted
+deb-src http://mirror.rackspace.com/ubuntu trusty-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://mirror.rackspace.com/ubuntu trusty universe
+deb-src http://mirror.rackspace.com/ubuntu trusty universe
+deb http://mirror.rackspace.com/ubuntu trusty-updates universe
+deb-src http://mirror.rackspace.com/ubuntu trusty-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team, and may not be under a free licence. Please satisfy yourself as to
+## your rights to use the software. Also, please note that software in
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://mirror.rackspace.com/ubuntu trusty multiverse
+deb-src http://mirror.rackspace.com/ubuntu trusty multiverse
+deb http://mirror.rackspace.com/ubuntu trusty-updates multiverse
+deb-src http://mirror.rackspace.com/ubuntu trusty-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://mirror.rackspace.com/ubuntu trusty-backports main restricted universe multiverse
+deb-src http://mirror.rackspace.com/ubuntu trusty-backports main restricted universe multiverse
+
+deb http://mirror.rackspace.com/ubuntu trusty-security main restricted
+deb-src http://mirror.rackspace.com/ubuntu trusty-security main restricted
+deb http://mirror.rackspace.com/ubuntu trusty-security universe
+deb-src http://mirror.rackspace.com/ubuntu trusty-security universe
+deb http://mirror.rackspace.com/ubuntu trusty-security multiverse
+deb-src http://mirror.rackspace.com/ubuntu trusty-security multiverse
+
+## Uncomment the following two lines to add software from Canonical's
+## 'partner' repository.
+## This software is not part of Ubuntu, but is offered by Canonical and the
+## respective vendors as a service to Ubuntu users.
+# deb http://archive.canonical.com/ubuntu trusty partner
+# deb-src http://archive.canonical.com/ubuntu trusty partner
+
+## Uncomment the following two lines to add software from Ubuntu's
+## 'extras' repository.
+## This software is not part of Ubuntu, but is offered by third-party
+## developers who want to ship their latest software.
+# deb http://extras.ubuntu.com/ubuntu trusty main
+# deb-src http://extras.ubuntu.com/ubuntu trusty main


### PR DESCRIPTION
Using a mirror (other than `archive.ubuntu.com`) is noticeably faster when building containers in a docker machine (that is, on a rackspace cloud server):

Before, with `archive.ubuntu.com`:
```
Fetched 21.8 MB in 52s (417 kB/s)
Fetched 7440 kB in 17s (421 kB/s)
Fetched 21.8 MB in 49s (445 kB/s)
Fetched 86.7 MB in 2min 59s (482 kB/s)
```

After, with `mirror.rackspace.com`:
```
Fetched 22.4 MB in 5s (4128 kB/s)
Fetched 7440 kB in 0s (20.5 MB/s)
Fetched 22.4 MB in 5s (3987 kB/s)
Fetched 86.7 MB in 4s (20.0 MB/s)
```

Not sure why there are different amounts of data - maybe different compression or something. But it works!
